### PR TITLE
Improve UI

### DIFF
--- a/arraiain-neverland/src/components/AddToQueueForm.jsx
+++ b/arraiain-neverland/src/components/AddToQueueForm.jsx
@@ -6,7 +6,9 @@ import {
   Stack,
   Paper,
   InputAdornment,
-  Typography
+  Typography,
+  Snackbar,
+  Alert
 } from '@mui/material';
 import PersonIcon from '@mui/icons-material/Person';
 import MusicNoteIcon from '@mui/icons-material/MusicNote';
@@ -15,6 +17,7 @@ import { supabase } from '../supabaseClient';
 
 export default function AddToQueueForm() {
   const [form, setForm] = useState({ singer: '', artist: '', music: '' });
+  const [open, setOpen] = useState(false);
 
   const handleChange = (e) => {
     setForm({ ...form, [e.target.name]: e.target.value });
@@ -24,6 +27,7 @@ export default function AddToQueueForm() {
     e.preventDefault();
     await supabase.from('karaoke_queue').insert([{ ...form, is_playing: false, status: 'waiting', position: 0 }]);
     setForm({ singer: '', artist: '', music: '' });
+    setOpen(true);
   };
 
   return (
@@ -84,6 +88,7 @@ export default function AddToQueueForm() {
               type="submit"
               variant="contained"
               fullWidth
+              disabled={!form.singer || !form.artist || !form.music}
               sx={{
                 backgroundColor: '#e17c2b',
                 borderRadius: '12px',
@@ -98,6 +103,16 @@ export default function AddToQueueForm() {
           </Stack>
         </form>
       </Paper>
+      <Snackbar
+        open={open}
+        autoHideDuration={3000}
+        onClose={() => setOpen(false)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert onClose={() => setOpen(false)} severity="success" sx={{ width: '100%' }}>
+          Música adicionada na fila!
+        </Alert>
+      </Snackbar>
     </Box>
   );
 }

--- a/arraiain-neverland/src/components/Header.jsx
+++ b/arraiain-neverland/src/components/Header.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Box, Typography, useMediaQuery, useTheme } from '@mui/material';
+import { Box, Typography, useMediaQuery, useTheme, Button } from '@mui/material';
+import { Link as RouterLink } from 'react-router-dom';
 
 export default function Header() {
   const theme = useTheme();
@@ -24,6 +25,8 @@ export default function Header() {
     >
       <Box sx={{ color: '#fff', textShadow: '1px 1px 2px #000', textAlign: { xs: 'center', sm: 'left' } }}>
         <Typography
+          component={RouterLink}
+          to="/"
           variant={isMobile ? 'h4' : 'h3'}
           sx={{
             fontFamily: '"Rock Salt", cursive',
@@ -31,6 +34,7 @@ export default function Header() {
             fontWeight: 700,
             lineHeight: 1.2,
             mb: 1,
+            textDecoration: 'none'
           }}
         >
           ARRAIÁ IN <br /> NEVERLAND
@@ -56,6 +60,18 @@ export default function Header() {
           boxShadow: '0 4px 12px rgba(0,0,0,0.4)',
         }}
       />
+      <Button
+        component={RouterLink}
+        to="/admin"
+        variant="contained"
+        color="secondary"
+        sx={{
+          mt: { xs: 3, sm: 0 },
+          fontWeight: 'bold',
+        }}
+      >
+        Painel
+      </Button>
     </Box>
   );
 }

--- a/arraiain-neverland/src/components/Layout.jsx
+++ b/arraiain-neverland/src/components/Layout.jsx
@@ -11,7 +11,7 @@ export default function Layout({ children }) {
         backgroundRepeat: 'repeat',
         backgroundSize: '40% auto',
         backgroundPosition: 'top center',
-        backgroundColor: '##E9791A',
+        backgroundColor: '#E9791A',
         pt: { xs: 8, sm: 10 },
         pb: 4,
       }}


### PR DESCRIPTION
## Summary
- fix Layout background color
- make header title link to home
- add Admin link in header
- show success snackbar after adding to queue
- disable add button until fields are filled

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6842ed95189c832ab06a4d476fa7c35b