### PR TITLE
Improve UI feedback and loading states

### DIFF
--- a/arraiain-neverland/README.md
+++ b/arraiain-neverland/README.md
@@ -1,6 +1,6 @@
-# React + Vite
+# Arraiá in Neverland Karaoke Queue
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Simple React + Vite application to manage karaoke sign ups with a Supabase backend.
 
 Currently, two official plugins are available:
 

--- a/arraiain-neverland/index.html
+++ b/arraiain-neverland/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@300;400;700&family=Rock+Salt&display=swap"
     rel="stylesheet">
-  <title>Vite + React</title>
+  <title>Arraiá in Neverland Karaoke</title>
 </head>
 
 <body>

--- a/arraiain-neverland/src/components/AddToQueueForm.jsx
+++ b/arraiain-neverland/src/components/AddToQueueForm.jsx
@@ -6,7 +6,8 @@ import {
   Stack,
   Paper,
   InputAdornment,
-  Typography
+  Typography,
+  Snackbar
 } from '@mui/material';
 import PersonIcon from '@mui/icons-material/Person';
 import MusicNoteIcon from '@mui/icons-material/MusicNote';
@@ -15,6 +16,8 @@ import { supabase } from '../supabaseClient';
 
 export default function AddToQueueForm() {
   const [form, setForm] = useState({ singer: '', artist: '', music: '' });
+  const [loading, setLoading] = useState(false);
+  const [snackOpen, setSnackOpen] = useState(false);
 
   const handleChange = (e) => {
     setForm({ ...form, [e.target.name]: e.target.value });
@@ -22,8 +25,16 @@ export default function AddToQueueForm() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    await supabase.from('karaoke_queue').insert([{ ...form, is_playing: false, status: 'waiting', position: 0 }]);
-    setForm({ singer: '', artist: '', music: '' });
+    if (!form.singer || !form.artist || !form.music) return;
+    setLoading(true);
+    const { error } = await supabase
+      .from('karaoke_queue')
+      .insert([{ ...form, is_playing: false, status: 'waiting', position: 0 }]);
+    setLoading(false);
+    if (!error) {
+      setSnackOpen(true);
+      setForm({ singer: '', artist: '', music: '' });
+    }
   };
 
   return (
@@ -84,6 +95,7 @@ export default function AddToQueueForm() {
               type="submit"
               variant="contained"
               fullWidth
+              disabled={!form.singer || !form.artist || !form.music || loading}
               sx={{
                 backgroundColor: '#e17c2b',
                 borderRadius: '12px',
@@ -93,8 +105,14 @@ export default function AddToQueueForm() {
                 '&:hover': { backgroundColor: '#d1671c' }
               }}
             >
-              ➕ Adicionar à fila
+              {loading ? 'Adicionando...' : '➕ Adicionar à fila'}
             </Button>
+            <Snackbar
+              open={snackOpen}
+              autoHideDuration={3000}
+              onClose={() => setSnackOpen(false)}
+              message="Música adicionada!"
+            />
           </Stack>
         </form>
       </Paper>

--- a/arraiain-neverland/src/components/AdminPanel.jsx
+++ b/arraiain-neverland/src/components/AdminPanel.jsx
@@ -9,18 +9,29 @@ import {
   Button,
   Stack,
   Chip,
+  CircularProgress,
+  Alert
 } from '@mui/material';
 
 export default function AdminPanel() {
   const [queue, setQueue] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
 
   useEffect(() => {
     fetchQueue();
   }, []);
 
   const fetchQueue = async () => {
-    const { data } = await supabase.from('karaoke_queue').select('*').order('created_at');
-    setQueue(data || []);
+    setLoading(true);
+    const { data, error } = await supabase.from('karaoke_queue').select('*').order('created_at');
+    if (error) {
+      setError('Erro ao carregar fila');
+    } else {
+      setQueue(data || []);
+      setError('');
+    }
+    setLoading(false);
   };
 
   const handlePlay = async (id) => {
@@ -50,6 +61,8 @@ export default function AdminPanel() {
       </Typography>
 
       <Stack spacing={3}>
+        {loading && <CircularProgress sx={{ alignSelf: 'center' }} />}
+        {error && <Alert severity="error">{error}</Alert>}
         {queue.map((item) => (
           <Card
             key={item.id}

--- a/arraiain-neverland/src/components/QueueDisplay.jsx
+++ b/arraiain-neverland/src/components/QueueDisplay.jsx
@@ -1,9 +1,20 @@
 import React, { useEffect, useState } from 'react';
 import { supabase } from '../supabaseClient';
-import { Typography, Box, Paper, List, ListItem, ListItemText } from '@mui/material';
+import {
+  Typography,
+  Box,
+  Paper,
+  List,
+  ListItem,
+  ListItemText,
+  CircularProgress,
+  Alert
+} from '@mui/material';
 
 export default function QueueDisplay() {
   const [queue, setQueue] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
 
   useEffect(() => {
     fetchQueue();
@@ -16,8 +27,15 @@ export default function QueueDisplay() {
   }, []);
 
   const fetchQueue = async () => {
-    const { data } = await supabase.from('karaoke_queue').select('*').order('created_at');
-    setQueue(data || []);
+    setLoading(true);
+    const { data, error } = await supabase.from('karaoke_queue').select('*').order('created_at');
+    if (error) {
+      setError('Erro ao carregar fila');
+    } else {
+      setQueue(data || []);
+      setError('');
+    }
+    setLoading(false);
   };
 
   const nowPlaying = queue.find((item) => item.is_playing);
@@ -25,6 +43,12 @@ export default function QueueDisplay() {
 
   return (
     <Box sx={{ mt: 4 }}>
+      {loading && <CircularProgress sx={{ display: 'block', mx: 'auto', mb: 2 }} />}
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
       <Paper sx={{ p: 3, borderRadius: '16px', backgroundColor: '#fce6c2', mb: 3 }}>
         <Typography variant="h6" sx={{ fontWeight: 'bold', mb: 1 }}>🖊 Agora cantando:</Typography>
         {nowPlaying ? (


### PR DESCRIPTION
## Summary
- refresh README for the karaoke queue app
- update page title
- add snackbar feedback for adding items
- show loading and error states in AdminPanel and QueueDisplay

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6842f215273c832aa0a04385ef767ee8